### PR TITLE
Update Font Awesome icon link to version 6

### DIFF
--- a/octoprint_mqttpublish/templates/mqttpublish_settings.jinja2
+++ b/octoprint_mqttpublish/templates/mqttpublish_settings.jinja2
@@ -4,7 +4,7 @@
 				<div class="span3"><h5>{{ _('Topic') }}</h5></div>
 				<div class="span2"><h5>{{ _('Message') }}</h5></div>
 				<div class="span2"><h5>{{ _('Label') }}</h5></div>
-				<div class="span2"><h5>{{ _('Icon Class') }} <a href="https://fontawesome.com/v4.7.0/icons/" target="_blank" title="Use fontawesome class name" class="btn btn-mini icon icon-question-sign"></a></h5></div>
+				<div class="span2"><h5>{{ _('Icon Class') }} <a href="https://fontawesome.com/v6/icons/" target="_blank" title="Use fontawesome class name" class="btn btn-mini icon icon-question-sign"></a></h5></div>
 				<div class="span1"><h5>{{ _('Con') }}/{{ _('Ret') }}</h5></div>
 				<div class="span2" style="text-align: center;"><h5><a href="#" class="btn btn-mini icon-plus" data-bind="click: addTopic"></a></h5></div>
 	</div>


### PR DESCRIPTION
small, low priority PR to bump up the version of FA linked to by the tooltip, as octoprint is using a more recent version of fontawesome.